### PR TITLE
Fixing the japanese version

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This site uses Next.js' internationalization and middleware features. MDX is use
 - [gr.hackclub.com](https://gr.hackclub.com)
 - [ms.hackclub.com](https://ms.hackclub.com)
 - [ur.hackclub.com](https://ur.hackclub.com)
-- [jp.hackclub.com](https://jp.hackclub.com)
+- [ja.hackclub.com](https://ja.hackclub.com)
 - [thai.hackclub.com](https://thai.hackclub.com)
 - [rw.hackclub.com](https://rw.hackclub.com)
 
@@ -32,8 +32,8 @@ This site uses Next.js' internationalization and middleware features. MDX is use
 4. Add your domain to the domains field in `next.config.js` following the format below. Unless we have acquired a special domain for the site you are adding, use a `.hackclub.com` subdomain.
     ```javascript
     {
-      domain: 'jp.hackclub.com',
-      defaultLocale: 'jp',
+      domain: 'ja.hackclub.com',
+      defaultLocale: 'ja',
       http: true
     }
     ```

--- a/next.config.js
+++ b/next.config.js
@@ -2,7 +2,7 @@ const withMDX = require('@next/mdx')({ extension: /\.mdx?$/ })
 module.exports = withMDX({
   pageExtensions: ['js', 'jsx', 'mdx'],
   i18n: {
-    locales: ['en', 'es', 'fr', 'zh', 'kr', 'tr', 'hin', 'pl', 'el', 'ms', 'bn', 'ur' , 'th', 'de', 'vi', 'rw'],
+    locales: ['en', 'es', 'fr', 'zh', 'kr', 'tr', 'hin', 'pl', 'el', 'ms', 'bn', 'ur' , 'th', 'de', 'vi', 'rw', 'ja'],
     defaultLocale: 'en',
     domains: [
       {
@@ -66,8 +66,8 @@ module.exports = withMDX({
         http: true
       },
       {
-        domain: 'jp.hackclub.com',
-        defaultLocale: 'jp',
+        domain: 'ja.hackclub.com',
+        defaultLocale: 'ja',
         http: true
       },
       {

--- a/pages/copy/ja.mdx
+++ b/pages/copy/ja.mdx
@@ -12,7 +12,7 @@ import { Container, Button, Heading } from 'theme-ui'
 <p>
   <Button
     as="a"
-    href="https://hackclub.com/?ref=fr"
+    href="https://hackclub.com/?ref=jp"
     variant="ctaLg"
     sx={{
       backgroundImage: t => t.util.gx('cyan', 'blue'),

--- a/pages/copy/ja.mdx
+++ b/pages/copy/ja.mdx
@@ -1,0 +1,33 @@
+import { Container, Button, Heading } from 'theme-ui'
+
+<Container variant="copy">
+
+<Heading as="h1">
+  学生によって、<br />
+  学生のために
+</Heading>
+
+ハッククラブは高校生のプログラミングクラブのネットワークで、学生はプロジェクトを作成することでコードを学びます。
+
+<p>
+  <Button
+    as="a"
+    href="https://hackclub.com/?ref=fr"
+    variant="ctaLg"
+    sx={{
+      backgroundImage: t => t.util.gx('cyan', 'blue'),
+      color: 'white'
+    }}
+  >
+    英語の完全なサイトを訪問してください！
+  </Button>
+</p>
+
+<img
+  alt="Students coding at a Hack Club event"
+  src="https://cloud-lapsqbi7m-hack-club-bot.vercel.app/0assemble.jpg"
+  width="512"
+  height="341"
+/>
+
+</Container>


### PR DESCRIPTION
This PR should update the country code (jp is the ISO 3166-1 **country code**, while ja is the ISO 639-1 **language code**). Since this repo is a translation repo, I assume we should be using ja. I also added the short translations for the ja.mdx.