### PR TITLE
Organizing README.md Sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,27 +1,25 @@
 # Hack Club Global Websites
 
-The goal of this project is to enable the creation of simplified versions of our Hack Club site that are translated into global languages. These sites should require practically no maintenance and be very brief. An example is [`gr.hackclub.com`](https://gr.hackclub.com).
+The goal of this project is to enable the creation of simplified versions of our Hack Club site that are translated into global languages. These sites should require practically no maintenance and be very brief. An example is [`fa.hackclub.com`](https://fa.hackclub.com).
 
 This site uses Next.js' internationalization and middleware features. MDX is used for content and Theme UI for styling.
 
 ## Sites
 
-- [hackclub.es](https://hackclub.es)
 - [bn.hackclub.com](https://bn.hackclub.com)
+- [fa.hackclub.com](https://fa.hackclub.com)
 - [fr.hackclub.com](https://fr.hackclub.com)
-- [zh.hackclub.com](https://zh.hackclub.com)
-- [kr.hackclub.com](https://kr.hackclub.com)
-- [tr.hackclub.com](https://tr.hackclub.com)
-- [hin.hackclub.com](https://hin.hackclub.com)
-- [pl.hackclub.com](https://pl.hackclub.com)
 - [gr.hackclub.com](https://gr.hackclub.com)
-- [ms.hackclub.com](https://ms.hackclub.com)
-- [ur.hackclub.com](https://ur.hackclub.com)
+- [hin.hackclub.com](https://hin.hackclub.com)
 - [ja.hackclub.com](https://ja.hackclub.com)
-- [thai.hackclub.com](https://thai.hackclub.com)
+- [kr.hackclub.com](https://kr.hackclub.com)
+- [ms.hackclub.com](https://ms.hackclub.com)
+- [pl.hackclub.com](https://pl.hackclub.com)
 - [rw.hackclub.com](https://rw.hackclub.com)
-- [it.hackclub.com](https://it.hackclub.com)
-- [id.hackclub.com](https://id.hackclub.com)
+- [thai.hackclub.com](https://thai.hackclub.com)
+- [tr.hackclub.com](https://tr.hackclub.com)
+- [ur.hackclub.com](https://ur.hackclub.com)
+- [zh.hackclub.com](https://zh.hackclub.com)
 
 ## Adding a Site
 


### PR DESCRIPTION
List of changes:

1. Changed the example from `gr.hackclub.com` to `fa.hackclub.com`
2. Rearranged the list of sites in alphabetical order (triple checked to make sure everything exists and works)
3. Removed `hackclub.es`, `id.hackclub.com` and `it.hackclub.com` because they aren't functional

If removing the ones that don't work is a bad idea I'll edit it and add them back.